### PR TITLE
Set the k2hb dashboards to start with last 3 hours by default for for…

### DIFF
--- a/dashboards/kafka-to-hbase.json.tpl
+++ b/dashboards/kafka-to-hbase.json.tpl
@@ -1,4 +1,6 @@
 {
+  "start": "-PT3H",
+  "periodOverride": "auto",
   "widgets": [
     {
       "type": "metric",


### PR DESCRIPTION
Set the k2hb dashboards to start with last 3 hours by default for for the stats to auto change when you change the dashboard time, at the moment they don't, which is useless