### PR TITLE
Refactor TF to make adding the new things easier - is a 99% NO-OP once applied

### DIFF
--- a/k2hb_ec2_asg_common.tf
+++ b/k2hb_ec2_asg_common.tf
@@ -339,79 +339,79 @@ resource "aws_security_group_rule" "ingress_k2hb_common_to_internet" {
 }
 
 resource "aws_security_group_rule" "k2hb_common_to_stub_broker" {
-  count             = data.terraform_remote_state.ingest.outputs.locals.k2hb_data_source_is_ucfs[local.environment] ? 0 : 1
+  count             = local.k2hb_data_source_is_ucfs[local.environment] ? 0 : 1
   description       = "Allow k2hb to reach stub Kafka brokers"
   type              = "egress"
-  from_port         = data.terraform_remote_state.ingest.outputs.locals.kafka_broker_port[local.environment]
-  to_port           = data.terraform_remote_state.ingest.outputs.locals.kafka_broker_port[local.environment]
+  from_port         = local.kafka_broker_port[local.environment]
+  to_port           = local.kafka_broker_port[local.environment]
   protocol          = "tcp"
-  cidr_blocks       = data.terraform_remote_state.ingest.outputs.stub_ucfs_subnets.cidr_block
+  cidr_blocks       = local.stub_ucfs_subnets_cidr_block
   security_group_id = aws_security_group.k2hb_common.id
 }
 
 resource "aws_security_group_rule" "k2hb_common_to_ucfs_broker" {
-  count             = data.terraform_remote_state.ingest.outputs.locals.k2hb_data_source_is_ucfs[local.environment] ? 1 : 0
+  count             = local.k2hb_data_source_is_ucfs[local.environment] ? 1 : 0
   description       = "Allow k2hb to reach UCFS Kafka brokers (Ireland)"
   type              = "egress"
-  from_port         = data.terraform_remote_state.ingest.outputs.locals.kafka_broker_port[local.environment]
-  to_port           = data.terraform_remote_state.ingest.outputs.locals.kafka_broker_port[local.environment]
+  from_port         = local.kafka_broker_port[local.environment]
+  to_port           = local.kafka_broker_port[local.environment]
   protocol          = "tcp"
-  cidr_blocks       = data.terraform_remote_state.ingest.outputs.locals.ucfs_broker_cidr_blocks[local.environment]
+  cidr_blocks       = local.ucfs_broker_cidr_blocks[local.environment]
   security_group_id = aws_security_group.k2hb_common.id
 }
 
 resource "aws_security_group_rule" "k2hb_common_to_ucfs_london_broker" {
-  count             = data.terraform_remote_state.ingest.outputs.locals.k2hb_data_source_is_ucfs[local.environment] ? 1 : 0
+  count             = local.k2hb_data_source_is_ucfs[local.environment] ? 1 : 0
   description       = "Allow k2hb to reach UCFS Kafka brokers (London)"
   type              = "egress"
-  from_port         = data.terraform_remote_state.ingest.outputs.locals.kafka_broker_port[local.environment]
-  to_port           = data.terraform_remote_state.ingest.outputs.locals.kafka_broker_port[local.environment]
+  from_port         = local.kafka_broker_port[local.environment]
+  to_port           = local.kafka_broker_port[local.environment]
   protocol          = "tcp"
-  cidr_blocks       = data.terraform_remote_state.ingest.outputs.locals.ucfs_london_broker_cidr_blocks[local.environment]
+  cidr_blocks       = local.ucfs_london_broker_cidr_blocks[local.environment]
   security_group_id = aws_security_group.k2hb_common.id
 }
 
 resource "aws_security_group_rule" "k2hb_common_to_ucfs_ireland_dns_tcp" {
-  count             = data.terraform_remote_state.ingest.outputs.locals.peer_with_ucfs[local.environment] ? 1 : 0
+  count             = local.peer_with_ucfs[local.environment] ? 1 : 0
   description       = "Allow k2hb to reach ucfs DNS name servers"
   type              = "egress"
   from_port         = 53
   to_port           = 53
   protocol          = "tcp"
-  cidr_blocks       = data.terraform_remote_state.ingest.outputs.locals.ucfs_nameservers_cidr_blocks[local.environment]
+  cidr_blocks       = local.ucfs_nameservers_cidr_blocks[local.environment]
   security_group_id = aws_security_group.k2hb_common.id
 }
 
 resource "aws_security_group_rule" "k2hb_common_to_ucfs_ireland_dns_udp" {
-  count             = data.terraform_remote_state.ingest.outputs.locals.peer_with_ucfs[local.environment] ? 1 : 0
+  count             = local.peer_with_ucfs[local.environment] ? 1 : 0
   description       = "Allow k2hb to reach ucfs DNS name servers"
   type              = "egress"
   from_port         = 53
   to_port           = 53
   protocol          = "udp"
-  cidr_blocks       = data.terraform_remote_state.ingest.outputs.locals.ucfs_nameservers_cidr_blocks[local.environment]
+  cidr_blocks       = local.ucfs_nameservers_cidr_blocks[local.environment]
   security_group_id = aws_security_group.k2hb_common.id
 }
 
 resource "aws_security_group_rule" "k2hb_common_to_ucfs_london_dns_tcp" {
-  count             = data.terraform_remote_state.ingest.outputs.locals.peer_with_ucfs_london[local.environment] ? 1 : 0
+  count             = local.peer_with_ucfs_london[local.environment] ? 1 : 0
   description       = "Allow k2hb to reach UCFS DNS (London)"
   type              = "egress"
   from_port         = 53
   to_port           = 53
   protocol          = "tcp"
-  cidr_blocks       = data.terraform_remote_state.ingest.outputs.locals.ucfs_london_nameservers_cidr_blocks[local.environment]
+  cidr_blocks       = local.ucfs_london_nameservers_cidr_blocks[local.environment]
   security_group_id = aws_security_group.k2hb_common.id
 }
 
 resource "aws_security_group_rule" "k2hb_common_to_ucfs_london_dns_udp" {
-  count             = data.terraform_remote_state.ingest.outputs.locals.peer_with_ucfs_london[local.environment] ? 1 : 0
+  count             = local.peer_with_ucfs_london[local.environment] ? 1 : 0
   description       = "Allow k2hb to reach UCFS DNS (London)"
   type              = "egress"
   from_port         = 53
   to_port           = 53
   protocol          = "udp"
-  cidr_blocks       = data.terraform_remote_state.ingest.outputs.locals.ucfs_london_nameservers_cidr_blocks[local.environment]
+  cidr_blocks       = local.ucfs_london_nameservers_cidr_blocks[local.environment]
   security_group_id = aws_security_group.k2hb_common.id
 }
 

--- a/k2hb_ec2_asg_equality.tf
+++ b/k2hb_ec2_asg_equality.tf
@@ -43,7 +43,7 @@ resource "aws_launch_template" "k2hb_equality" {
     s3_artefact_bucket_id = data.terraform_remote_state.management_artefact.outputs.artefact_bucket.id
 
     hbase_master_url                                 = data.terraform_remote_state.ingest.outputs.aws_emr_cluster.fqdn
-    k2hb_max_memory_allocation                       = var.k2hb_max_memory_allocation_equality[local.environment]
+    k2hb_max_memory_allocation                       = var.k2hb_main_max_memory_allocation_equality[local.environment]
     cwa_metrics_collection_interval                  = local.cw_agent_metrics_collection_interval
     cwa_namespace                                    = local.cw_k2hb_equality_agent_namespace
     cwa_cpu_metrics_collection_interval              = local.cw_agent_cpu_metrics_collection_interval
@@ -94,20 +94,20 @@ resource "aws_launch_template" "k2hb_equality" {
     k2hb_kafka_poll_timeout                          = local.kafka_k2hb_poll_timeout[local.environment]
     k2hb_kafka_insecure                              = "false"
     k2hb_kafka_cert_mode                             = "RETRIEVE"
-    k2hb_kafka_dlq_topic                             = local.dlq_kafka_consumer_topics[local.environment]
+    k2hb_kafka_dlq_topic                             = local.dlq_kafka_consumer_topic
     k2hb_kafka_poll_max_records                      = local.k2hb_max_poll_records_count_equality[local.environment]
     k2hb_kafka_report_frequency                      = local.k2hb_report_frequency[local.environment]
     k2hb_qualified_table_pattern                     = local.k2hb_data_equality_qualified_table_pattern
     k2hb_check_existence                             = local.k2hb_check_existence[local.environment]
-    k2hb_aws_s3_archive_bucket                       = data.terraform_remote_state.ingest.outputs.corporate_storage_bucket.id
-    k2hb_aws_s3_archive_directory                    = "${data.terraform_remote_state.ingest.outputs.corporate_storage.corporate_storage_directory_prefix}/${data.terraform_remote_state.ingest.outputs.corporate_storage.corporate_storage_bucket_directory.ucfs_equality}"
+    k2hb_aws_s3_archive_bucket                       = local.k2hb_aws_s3_archive_bucket_id
+    k2hb_aws_s3_archive_directory                    = local.k2hb_aws_s3_equality_archive_directory
     k2hb_aws_s3_batch_puts                           = "true"
     k2hb_validator_schema                            = local.k2hb_validator_schema.equality
     k2hb_write_to_metadata_store                     = local.k2hb_equality_write_to_metadata_store[local.environment]
     k2hb_manifest_bucket                             = data.terraform_remote_state.internal_compute.outputs.manifest_bucket.id
     k2hb_manifest_prefix                             = data.terraform_remote_state.ingest.outputs.k2hb_manifest_write_locations.equality_prefix
-    k2hb_write_manifests                             = local.k2hb_write_manifests_equality[local.environment]
-    k2hb_auto_commit_metadata_store_inserts          = local.k2hb_auto_commit_metadata_store_inserts_equality[local.environment]
+    k2hb_write_manifests                             = local.k2hb_equality_write_manifests[local.environment]
+    k2hb_auto_commit_metadata_store_inserts          = local.k2hb_equality_auto_commit_metadata_store_inserts[local.environment]
   }))
 
   instance_initiated_shutdown_behavior = "terminate"

--- a/k2hb_log_groups.tf
+++ b/k2hb_log_groups.tf
@@ -1,0 +1,8 @@
+# TODO - import the main and audit log groups here
+
+# Current as at Aug 2020 - don't change the resource or logical name!
+resource "aws_cloudwatch_log_group" "k2hb_ec2_audit_logs" {
+  name              = local.k2hb_ec2_audit_logs_name
+  retention_in_days = 180
+  tags              = local.common_tags
+}

--- a/k2hb_monitoring_equality.tf
+++ b/k2hb_monitoring_equality.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_metric_filter" "number_of_batches_written_filter_k2hb_equalities" {
-  log_group_name = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_equality_logs.name
+  log_group_name = local.k2hb_ec2_equality_logs_name
   name           = local.k2hb_metric_name_number_of_successfully_processed_batches
   pattern        = "{ $.message = \"Processed batch\" }"
 
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_log_metric_filter" "number_of_batches_written_filter_k2
 }
 
 resource "aws_cloudwatch_log_metric_filter" "rate_of_records_written_filter_k2hb_equalities" {
-  log_group_name = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_equality_logs.name
+  log_group_name = local.k2hb_ec2_equality_logs_name
   name           = local.k2hb_metric_name_number_of_successfully_processed_records
   pattern        = "{ $.message = \"Processed batch\" }"
 
@@ -23,7 +23,7 @@ resource "aws_cloudwatch_log_metric_filter" "rate_of_records_written_filter_k2hb
 }
 
 resource "aws_cloudwatch_log_metric_filter" "time_to_process_batch_filter_k2hb_equalities" {
-  log_group_name = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_equality_logs.name
+  log_group_name = local.k2hb_ec2_equality_logs_name
   name           = local.k2hb_metric_name_speed_of_successfully_processed_batches
   pattern        = "{ $.message = \"Processed batch\" }"
 
@@ -38,7 +38,7 @@ module "rate_of_dlq_messages_written_filter_k2hb_alarm_equalities" {
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.6"
 
-  log_group_name      = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_equality_logs.name
+  log_group_name      = local.k2hb_ec2_equality_logs_name
   metric_namespace    = local.cw_k2hb_equality_agent_namespace
   pattern             = "{ $.message = \"Error processing record, sending to dlq\" }"
   alarm_name          = "K2HB equalities - Messages written to DLQ in last half an hour"
@@ -56,7 +56,7 @@ module "kafka_read_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.6"
 
-  log_group_name      = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_equality_logs.name
+  log_group_name      = local.k2hb_ec2_equality_logs_name
   metric_namespace    = local.cw_k2hb_equality_agent_namespace
   pattern             = "{ $.message = \"Error reading from Kafka\" }"
   alarm_name          = "K2HB equalities - Kafka read timeout occurrences exceeds 5 in last hour"
@@ -74,7 +74,7 @@ module "hbase_batch_failures_greater_than_threshold_filter_k2hb_alarm_equalities
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.6"
 
-  log_group_name      = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_equality_logs.name
+  log_group_name      = local.k2hb_ec2_equality_logs_name
   metric_namespace    = local.cw_k2hb_equality_agent_namespace
   pattern             = "{ $.message = \"Failed to put batch into hbase\"}"
   alarm_name          = "K2HB equalities - Hbase write failures exceeds 5 in last hour"
@@ -92,7 +92,7 @@ module "hbase_connection_timeout_occurrences_greater_than_threshold_filter_k2hb_
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.6"
 
-  log_group_name      = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_equality_logs.name
+  log_group_name      = local.k2hb_ec2_equality_logs_name
   metric_namespace    = local.cw_k2hb_equality_agent_namespace
   pattern             = "{ $.message = \"Error connecting to Hbase\" }"
   alarm_name          = "K2HB equalities - Hbase connection timeout occurrences exceeds 5 in last hour"
@@ -107,7 +107,7 @@ module "hbase_connection_timeout_occurrences_greater_than_threshold_filter_k2hb_
 }
 
 resource "aws_cloudwatch_log_metric_filter" "consumer_lag_k2hb_equalities" {
-  log_group_name = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_equality_logs.name
+  log_group_name = local.k2hb_ec2_equality_logs_name
   name           = local.k2hb_metric_name_lag_per_partition
   pattern        = "{ $.message = \"Max record lag\" && $.base_lag != \"NaN\"  }"
 
@@ -141,7 +141,7 @@ resource "aws_cloudwatch_metric_alarm" "consumer_lag_k2hb_alarm_equalities" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "failed_k2hb_batches_equalities" {
-  log_group_name = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_equality_logs.name
+  log_group_name = local.k2hb_ec2_equality_logs_name
   name           = local.k2hb_metric_name_failed_batches
   pattern        = "{ $.message = \"Batch failed, not committing offset, resetting position to last commit\" }"
 

--- a/k2hb_monitoring_main.tf
+++ b/k2hb_monitoring_main.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_metric_filter" "number_of_batches_written_filter_k2hb_ucfs" {
-  log_group_name = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_logs.name
+  log_group_name = local.k2hb_ec2_business_logs_name
   name           = local.k2hb_metric_name_number_of_successfully_processed_batches
   pattern        = "{ $.message = \"Processed batch\" }"
 
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_log_metric_filter" "number_of_batches_written_filter_k2
 }
 
 resource "aws_cloudwatch_log_metric_filter" "rate_of_records_written_filter_k2hb_ucfs" {
-  log_group_name = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_logs.name
+  log_group_name = local.k2hb_ec2_business_logs_name
   name           = local.k2hb_metric_name_number_of_successfully_processed_records
   pattern        = "{ $.message = \"Processed batch\" }"
 
@@ -23,7 +23,7 @@ resource "aws_cloudwatch_log_metric_filter" "rate_of_records_written_filter_k2hb
 }
 
 resource "aws_cloudwatch_log_metric_filter" "time_to_process_batch_filter_k2hb_ucfs" {
-  log_group_name = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_logs.name
+  log_group_name = local.k2hb_ec2_business_logs_name
   name           = local.k2hb_metric_name_speed_of_successfully_processed_batches
   pattern        = "{ $.message = \"Processed batch\" }"
 
@@ -38,7 +38,7 @@ module "rate_of_dlq_messages_written_filter_k2hb_alarm_ucfs" {
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.6"
 
-  log_group_name      = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_logs.name
+  log_group_name      = local.k2hb_ec2_business_logs_name
   metric_namespace    = local.cw_k2hb_agent_namespace
   pattern             = "{ $.message = \"Error processing record, sending to dlq\" }"
   alarm_name          = "K2HB UCFS - Messages written to DLQ in last half an hour"
@@ -56,7 +56,7 @@ module "kafka_read_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.6"
 
-  log_group_name      = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_logs.name
+  log_group_name      = local.k2hb_ec2_business_logs_name
   metric_namespace    = local.cw_k2hb_agent_namespace
   pattern             = "{ $.message = \"Error reading from Kafka\" }"
   alarm_name          = "K2HB UCFS - Kafka read timeout occurrences exceeds 5 in last hour"
@@ -74,7 +74,7 @@ module "hbase_batch_failures_greater_than_threshold_filter_k2hb_alarm_ucfs" {
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.6"
 
-  log_group_name      = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_logs.name
+  log_group_name      = local.k2hb_ec2_business_logs_name
   metric_namespace    = local.cw_k2hb_agent_namespace
   pattern             = "{ $.message = \"Failed to put batch into hbase\"}"
   alarm_name          = "K2HB UCFS - Hbase write failures exceeds 5 in last hour"
@@ -92,7 +92,7 @@ module "hbase_connection_timeout_occurrences_greater_than_threshold_filter_k2hb_
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.6"
 
-  log_group_name      = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_logs.name
+  log_group_name      = local.k2hb_ec2_business_logs_name
   metric_namespace    = local.cw_k2hb_agent_namespace
   pattern             = "{ $.message = \"Error connecting to Hbase\" }"
   alarm_name          = "K2HB UCFS - Hbase connection timeout occurrences exceeds 5 in last hour"
@@ -107,7 +107,7 @@ module "hbase_connection_timeout_occurrences_greater_than_threshold_filter_k2hb_
 }
 
 resource "aws_cloudwatch_log_metric_filter" "consumer_lag_k2hb_ucfs" {
-  log_group_name = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_logs.name
+  log_group_name = local.k2hb_ec2_business_logs_name
   name           = local.k2hb_metric_name_lag_per_partition
   pattern        = "{ $.message = \"Max record lag\" && $.base_lag != \"NaN\"  }"
 
@@ -141,7 +141,7 @@ resource "aws_cloudwatch_metric_alarm" "consumer_lag_k2hb_alarm_ucfs" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "failed_k2hb_batches_ucfs" {
-  log_group_name = data.terraform_remote_state.ingest.outputs.log_groups.k2hb_ec2_logs.name
+  log_group_name = local.k2hb_ec2_business_logs_name
   name           = local.k2hb_metric_name_failed_batches
   pattern        = "{ $.message = \"Batch failed, not committing offset, resetting position to last commit\" }"
 

--- a/locals.tf
+++ b/locals.tf
@@ -144,6 +144,7 @@ locals {
 
   k2hb_kafka_main_consumer_group     = "dataworks-ucfs-kafka-to-hbase-ingest-${local.environment}"
   k2hb_kafka_equality_consumer_group = "dataworks-ucfs-kafka-equality-to-hbase-ingest-${local.environment}"
+  k2hb_kafka_audit_consumer_group    = "dataworks-ucfs-kafka-audit-to-hbase-ingest-${local.environment}"
 
   kafka_consumer_truststore_aliases = {
     development = "ucfs_ca"
@@ -319,10 +320,9 @@ locals {
 
   // DW-4748 & DW-4827 - Allow extra dot in last matcher group for db.crypto.encryptedData.unencrypted
   k2hb_main_data_qualified_table_pattern = "^\\w+\\.([-\\w]+)\\.([-.\\w]+)$"
-
   // Only needs to work for exactly "data.equality"
   k2hb_data_equality_qualified_table_pattern = "^([-\\w]+)\\.([-\\w]+)$"
-  // This will be used when we consume audit data
+  // Only needs to work for exactly "data.businessAudit"
   k2hb_data_audit_qualified_table_pattern = "^([-\\w]+)\\.([-\\w]+)$"
 
   dlq_kafka_consumer_topics = {
@@ -384,7 +384,9 @@ locals {
     },
   ]
 
-  #### Import lots the things we need from dip/aws-ingest in one place to make our tf cleaner in this repo ####
+  #### Import lots of the things we need from dip/aws-ingest in one place to make our tf cleaner in this repo ####
+
+  ingest_corporate_storage = data.terraform_remote_state.ingest.outputs.corporate_storage
 
   stub_kafka_broker_port_https = data.terraform_remote_state.ingest.outputs.locals.stub_kafka_broker_port_https
   stub_bootstrap_servers       = data.terraform_remote_state.ingest.outputs.locals.kafka_bootstrap_servers

--- a/locals.tf
+++ b/locals.tf
@@ -392,7 +392,7 @@ locals {
   stub_ucfs_subnets_cidr_block = data.terraform_remote_state.ingest.outputs.stub_ucfs_subnets.cidr_block
 
   uc_kafaka_broker_port_https         = data.terraform_remote_state.ingest.outputs.locals.uc_kafaka_broker_port_https
-  ucfs_ha_cluster_bootstrap_servers   = data.terraform_remote_state.ingest.outputs.locals.ucfs_ha_cluster_bootstrap_serversucfs_ha_cluster_bootstrap_servers
+  ucfs_ha_cluster_bootstrap_servers   = data.terraform_remote_state.ingest.outputs.locals.ucfs_ha_cluster_bootstrap_servers
   ucfs_broker_cidr_blocks             = data.terraform_remote_state.ingest.outputs.locals.ucfs_broker_cidr_blocks
   ucfs_london_broker_cidr_blocks      = data.terraform_remote_state.ingest.outputs.locals.ucfs_london_broker_cidr_blocks
   ucfs_nameservers_cidr_blocks        = data.terraform_remote_state.ingest.outputs.locals.ucfs_nameservers_cidr_blocks

--- a/locals.tf
+++ b/locals.tf
@@ -432,7 +432,7 @@ locals {
   k2hb_aws_s3_main_archive_directory     = "${data.terraform_remote_state.ingest.outputs.corporate_storage.corporate_storage_directory_prefix}/${data.terraform_remote_state.ingest.outputs.corporate_storage.corporate_storage_bucket_directory.ucfs_main}"
   k2hb_aws_s3_equality_archive_directory = "${data.terraform_remote_state.ingest.outputs.corporate_storage.corporate_storage_directory_prefix}/${data.terraform_remote_state.ingest.outputs.corporate_storage.corporate_storage_bucket_directory.ucfs_equality}"
 
-  ingest_corporate_storage_directory_prefix = data.terraform_remote_state.ingest.outputs.corporate_storage.local.corporate_storage_directory_prefix
+  ingest_corporate_storage_directory_prefix = data.terraform_remote_state.ingest.outputs.corporate_storage.corporate_storage_directory_prefix
   ingest_corporate_storage_bucket           = data.terraform_remote_state.ingest.outputs.corporate_storage_bucket
 
   stub_kafka_broker_port_https = data.terraform_remote_state.ingest.outputs.locals.stub_kafka_broker_port_https

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,12 +2,12 @@
 output "asg_properties" {
   value = {
     max_counts = {
-      k2hb_main_ha_cluster   = var.k2hb_main_ha_cluster_asg_max[local.environment]
-      k2hb_equality          = var.k2hb_equality_asg_max[local.environment]
+      k2hb_main_ha_cluster = var.k2hb_main_ha_cluster_asg_max[local.environment]
+      k2hb_equality        = var.k2hb_equality_asg_max[local.environment]
     }
     prefixes = {
-      k2hb_main_ha_cluster   = aws_autoscaling_group.k2hb_main_ha_cluster.name
-      k2hb_equality          = aws_autoscaling_group.k2hb_equality.name
+      k2hb_main_ha_cluster = aws_autoscaling_group.k2hb_main_ha_cluster.name
+      k2hb_equality        = aws_autoscaling_group.k2hb_equality.name
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,7 +2,7 @@
 output "asg_properties" {
   value = {
     max_counts = {
-      k2hb_main_ha_cluster = var.k2hb_main_ha_cluster_asg_max[local.environment]
+      k2hb_main_ha_cluster = var.k2hb_main_asg_max[local.environment]
       k2hb_equality        = var.k2hb_equality_asg_max[local.environment]
     }
     prefixes = {

--- a/resolver.tf
+++ b/resolver.tf
@@ -1,20 +1,20 @@
 resource "aws_route53_resolver_endpoint" "ucfs_resolver" {
-  count     = (data.terraform_remote_state.ingest.outputs.locals.peer_with_ucfs[local.environment] || data.terraform_remote_state.ingest.outputs.locals.peer_with_ucfs_london[local.environment]) ? 1 : 0
+  count     = (local.peer_with_ucfs[local.environment] || local.peer_with_ucfs_london[local.environment]) ? 1 : 0
   name      = "ucfs_resolver"
   direction = "OUTBOUND"
 
   security_group_ids = [aws_security_group.k2hb_common.id]
 
   ip_address {
-    subnet_id = data.terraform_remote_state.ingest.outputs.ingestion_subnets.id[0]
+    subnet_id = local.ingestion_subnets.id[0]
   }
 
   ip_address {
-    subnet_id = data.terraform_remote_state.ingest.outputs.ingestion_subnets.id[1]
+    subnet_id = local.ingestion_subnets.id[1]
   }
 
   ip_address {
-    subnet_id = data.terraform_remote_state.ingest.outputs.ingestion_subnets.id[2]
+    subnet_id = local.ingestion_subnets.id[2]
   }
 
   tags = merge(
@@ -26,18 +26,18 @@ resource "aws_route53_resolver_endpoint" "ucfs_resolver" {
 }
 
 resource "aws_route53_resolver_rule" "ucfs_resolver_rule" {
-  count                = data.terraform_remote_state.ingest.outputs.locals.peer_with_ucfs[local.environment] ? 1 : 0
-  domain_name          = data.terraform_remote_state.ingest.outputs.locals.ucfs_domains[local.environment]
+  count                = local.peer_with_ucfs[local.environment] ? 1 : 0
+  domain_name          = local.ucfs_domains[local.environment]
   name                 = "ucfs_resolver_rule"
   rule_type            = "FORWARD"
   resolver_endpoint_id = aws_route53_resolver_endpoint.ucfs_resolver[0].id
 
   target_ip {
-    ip = element(data.terraform_remote_state.ingest.outputs.locals.ucfs_nameservers[local.environment], 0)
+    ip = element(local.ucfs_nameservers[local.environment], 0)
   }
 
   target_ip {
-    ip = element(data.terraform_remote_state.ingest.outputs.locals.ucfs_nameservers[local.environment], 1)
+    ip = element(local.ucfs_nameservers[local.environment], 1)
   }
 
   tags = merge(
@@ -49,24 +49,24 @@ resource "aws_route53_resolver_rule" "ucfs_resolver_rule" {
 }
 
 resource "aws_route53_resolver_rule_association" "ucfs_resolver_rule_association" {
-  count            = data.terraform_remote_state.ingest.outputs.locals.peer_with_ucfs[local.environment] ? 1 : 0
+  count            = local.peer_with_ucfs[local.environment] ? 1 : 0
   resolver_rule_id = aws_route53_resolver_rule.ucfs_resolver_rule[0].id
-  vpc_id           = data.terraform_remote_state.ingest.outputs.vpc.vpc.vpc.id
+  vpc_id           = local.ingest_vpc_id
 }
 
 resource "aws_route53_resolver_rule" "ucfs_london_resolver_rule" {
-  count                = data.terraform_remote_state.ingest.outputs.locals.peer_with_ucfs_london[local.environment] ? 1 : 0
-  domain_name          = data.terraform_remote_state.ingest.outputs.locals.ucfs_london_domains[local.environment]
+  count                = local.peer_with_ucfs_london[local.environment] ? 1 : 0
+  domain_name          = local.ucfs_london_domains[local.environment]
   name                 = "ucfs_london_resolver_rule"
   rule_type            = "FORWARD"
   resolver_endpoint_id = aws_route53_resolver_endpoint.ucfs_resolver[0].id
 
   target_ip {
-    ip = element(data.terraform_remote_state.ingest.outputs.locals.ucfs_london_nameservers[local.environment], 0)
+    ip = element(local.ucfs_london_nameservers[local.environment], 0)
   }
 
   target_ip {
-    ip = element(data.terraform_remote_state.ingest.outputs.locals.ucfs_london_nameservers[local.environment], 1)
+    ip = element(local.ucfs_london_nameservers[local.environment], 1)
   }
 
   tags = merge(
@@ -78,7 +78,7 @@ resource "aws_route53_resolver_rule" "ucfs_london_resolver_rule" {
 }
 
 resource "aws_route53_resolver_rule_association" "ucfs_london_resolver_rule_association" {
-  count            = data.terraform_remote_state.ingest.outputs.locals.peer_with_ucfs_london[local.environment] ? 1 : 0
+  count            = local.peer_with_ucfs_london[local.environment] ? 1 : 0
   resolver_rule_id = aws_route53_resolver_rule.ucfs_london_resolver_rule[0].id
-  vpc_id           = data.terraform_remote_state.ingest.outputs.vpc.vpc.vpc.id
+  vpc_id           = local.ingest_vpc_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,17 @@ variable "k2hb_equality_ec2_size" {
   }
 }
 
-variable "k2hb_max_memory_allocation_main" {
+variable "k2hb_audit_ec2_size" {
+  default = {
+    development = "t3.medium"
+    qa          = "t3.medium"
+    integration = "t3.medium"
+    preprod     = "t3.medium"
+    production  = "c5.large"
+  }
+}
+
+variable "k2hb_main_max_memory_allocation" {
   default = {
     development = "-Xmx1g"
     qa          = "-Xmx1g"
@@ -54,7 +64,7 @@ variable "k2hb_max_memory_allocation_main" {
   }
 }
 
-variable "k2hb_max_memory_allocation_equality" {
+variable "k2hb_main_max_memory_allocation_equality" {
   default = {
     development = "-Xmx1g"
     qa          = "-Xmx1g"
@@ -64,7 +74,17 @@ variable "k2hb_max_memory_allocation_equality" {
   }
 }
 
-variable "k2hb_main_ha_cluster_asg_desired" {
+variable "k2hb_audit_max_memory_allocation" {
+  default = {
+    development = "-Xmx1g"
+    qa          = "-Xmx1g"
+    integration = "-Xmx1g"
+    preprod     = "-Xmx1g"
+    production  = "-Xmx2g"
+  }
+}
+
+variable "k2hb_main_asg_desired" {
   description = "Desired k2hb ha consumer asg size. UC Prod HA Cluster has 20 partitions, and we need spares. We can have at most 30 to fit in the subnets, as changes with create-before-destroy mean we need double headroom"
   default = {
     development = 2 //stubbed env
@@ -75,7 +95,7 @@ variable "k2hb_main_ha_cluster_asg_desired" {
   }
 }
 
-variable "k2hb_main_ha_cluster_asg_max" {
+variable "k2hb_main_asg_max" {
   description = "Max k2hb ha consumer asg size. UC Prod HA Cluster has 20 partitions, and we need spares. We can have at most 30 to fit in the subnets, as changes with create-before-destroy mean we need double headroom"
   default = {
     development = 2 //stubbed env
@@ -86,12 +106,34 @@ variable "k2hb_main_ha_cluster_asg_max" {
   }
 }
 
+variable "k2hb_main_london_asg_desired" {
+  description = "Desired k2hb ha consumer asg size. UC Prod HA Cluster has 20 partitions, and we need spares. We can have at most 30 to fit in the subnets, as changes with create-before-destroy mean we need double headroom"
+  default = {
+    development = 0 //stubbed env
+    qa          = 0 //stubbed env
+    integration = 0 //stubbed env
+    preprod     = 0
+    production  = 0
+  }
+}
+
+variable "k2hb_main_london_asg_max" {
+  description = "Max k2hb ha consumer asg size. UC Prod HA Cluster has 20 partitions, and we need spares. We can have at most 30 to fit in the subnets, as changes with create-before-destroy mean we need double headroom"
+  default = {
+    development = 1 //stubbed env
+    qa          = 1 //stubbed env
+    integration = 1 //stubbed env
+    preprod     = 1
+    production  = 1
+  }
+}
+
 variable "k2hb_equality_asg_desired" {
   description = "Desired k2hb equality asg size. Connects to ha cluster."
   default = {
-    development = 1
-    qa          = 1
-    integration = 1
+    development = 1 //stubbed env
+    qa          = 1 //stubbed env
+    integration = 1 //stubbed env
     preprod     = 1
     production  = 1
   }
@@ -100,9 +142,53 @@ variable "k2hb_equality_asg_desired" {
 variable "k2hb_equality_asg_max" {
   description = "Max k2hb equality asg size. Connects to ha cluster."
   default = {
-    development = 1
-    qa          = 1
-    integration = 1
+    development = 1 //stubbed env
+    qa          = 1 //stubbed env
+    integration = 1 //stubbed env
+    preprod     = 1
+    production  = 1
+  }
+}
+
+variable "k2hb_equality_london_asg_desired" {
+  description = "Desired k2hb equality asg size. Connects to ha cluster."
+  default = {
+    development = 0 //stubbed env
+    qa          = 0 //stubbed env
+    integration = 0 //stubbed env
+    preprod     = 0
+    production  = 0
+  }
+}
+
+variable "k2hb_equality_london_asg_max" {
+  description = "Max k2hb equality asg size. Connects to ha cluster."
+  default = {
+    development = 1 //stubbed env
+    qa          = 1 //stubbed env
+    integration = 1 //stubbed env
+    preprod     = 1
+    production  = 1
+  }
+}
+
+variable "k2hb_audit_london_asg_desired" {
+  description = "Desired k2hb equality asg size. Connects to ha cluster."
+  default = {
+    development = 0 //stubbed env
+    qa          = 0 //stubbed env
+    integration = 0 //stubbed env
+    preprod     = 0
+    production  = 0
+  }
+}
+
+variable "k2hb_audit_london_asg_max" {
+  description = "Max k2hb equality asg size. Connects to ha cluster."
+  default = {
+    development = 1 //stubbed env
+    qa          = 1 //stubbed env
+    integration = 1 //stubbed env
     preprod     = 1
     production  = 1
   }


### PR DESCRIPTION
Refactor TF to make adding the new things easier - is a 99% NO-OP once applied
Work out lots of the broker settings in here not ingest - but get all sensitive info from ingest.
Add the audit log group before any k2hb exists to use it - that way TF makes it first.
Set up all vars we need for adding London consumers and Audit consumers. - but don't add them yet.