### PR TITLE
Flip all non-prod stacks to London

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -87,109 +87,109 @@ variable "k2hb_audit_max_memory_allocation" {
 variable "k2hb_main_asg_desired" {
   description = "Desired k2hb ha consumer asg size. UC Prod HA Cluster has 20 partitions, and we need spares. We can have at most 30 to fit in the subnets, as changes with create-before-destroy mean we need double headroom"
   default = {
-    development = 2 //stubbed env
-    qa          = 2 //stubbed env
-    integration = 2 //stubbed env
-    preprod     = 2
-    production  = 21
+    development = 0 //stubbed env
+    qa          = 0 //stubbed env
+    integration = 0 //stubbed env and UC now in London
+    preprod     = 0 // UC now in London
+    production  = 21 // Switch to London on 21 Nov 2020
   }
 }
 
 variable "k2hb_main_asg_max" {
   description = "Max k2hb ha consumer asg size. UC Prod HA Cluster has 20 partitions, and we need spares. We can have at most 30 to fit in the subnets, as changes with create-before-destroy mean we need double headroom"
   default = {
-    development = 2 //stubbed env
-    qa          = 2 //stubbed env
-    integration = 2 //stubbed env
-    preprod     = 2
-    production  = 21
+    development = 0 //stubbed env
+    qa          = 0 //stubbed env
+    integration = 0 //stubbed env and now in London
+    preprod     = 0 // UC now in London
+    production  = 21 // Switch to London on 21 Nov 2020
   }
 }
 
 variable "k2hb_main_london_asg_desired" {
   description = "Desired k2hb ha consumer asg size. UC Prod HA Cluster has 20 partitions, and we need spares. We can have at most 30 to fit in the subnets, as changes with create-before-destroy mean we need double headroom"
   default = {
-    development = 0 //stubbed env
-    qa          = 0 //stubbed env
-    integration = 1 //stubbed env
-    preprod     = 1
-    production  = 0
+    development = 2 //stubbed env
+    qa          = 2 //stubbed env
+    integration = 2 //stubbed env + UC now in London
+    preprod     = 2 // UC now in London
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
 variable "k2hb_main_london_asg_max" {
   description = "Max k2hb ha consumer asg size. UC Prod HA Cluster has 20 partitions, and we need spares. We can have at most 30 to fit in the subnets, as changes with create-before-destroy mean we need double headroom"
   default = {
-    development = 0 //stubbed env
-    qa          = 0 //stubbed env
-    integration = 1 //stubbed env
-    preprod     = 1
-    production  = 0
+    development = 2 //stubbed env
+    qa          = 2 //stubbed env
+    integration = 2 //stubbed env
+    preprod     = 2 // UC now in London
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
 variable "k2hb_equality_asg_desired" {
   description = "Desired k2hb equality asg size. Connects to ha cluster."
   default = {
-    development = 1 //stubbed env
-    qa          = 1 //stubbed env
-    integration = 1 //stubbed env
-    preprod     = 1
-    production  = 1
+    development = 0 //stubbed env
+    qa          = 0 //stubbed env
+    integration = 0 //stubbed env and now in London
+    preprod     = 0 // UC now in London
+    production  = 1 // Switch to London on 21 Nov 2020
   }
 }
 
 variable "k2hb_equality_asg_max" {
   description = "Max k2hb equality asg size. Connects to ha cluster."
   default = {
-    development = 1 //stubbed env
-    qa          = 1 //stubbed env
-    integration = 1 //stubbed env
-    preprod     = 1
-    production  = 1
+    development = 0 //stubbed env
+    qa          = 0 //stubbed env
+    integration = 0 //stubbed env and now in London
+    preprod     = 0 // UC now in London
+    production  = 1 // Switch to London on 21 Nov 2020
   }
 }
 
 variable "k2hb_equality_london_asg_desired" {
   description = "Desired k2hb equality asg size. Connects to ha cluster."
   default = {
-    development = 0 //stubbed env
-    qa          = 0 //stubbed env
-    integration = 1 //stubbed env
-    preprod     = 1
-    production  = 0
+    development = 1 //stubbed env
+    qa          = 1 //stubbed env
+    integration = 1 //stubbed env + UC now in London
+    preprod     = 1 // UC now in London
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
 variable "k2hb_equality_london_asg_max" {
   description = "Max k2hb equality asg size. Connects to ha cluster."
   default = {
-    development = 0 //stubbed env
-    qa          = 0 //stubbed env
-    integration = 1 //stubbed env
-    preprod     = 1
-    production  = 0
+    development = 1 //stubbed env
+    qa          = 1 //stubbed env
+    integration = 1 //stubbed env + UC now in London
+    preprod     = 1 // UC now in London
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
 variable "k2hb_audit_london_asg_desired" {
   description = "Desired k2hb equality asg size. Connects to ha cluster."
   default = {
-    development = 0 //stubbed env
-    qa          = 0 //stubbed env
-    integration = 1 //stubbed env
-    preprod     = 1
-    production  = 1
+    development = 1 //stubbed env
+    qa          = 1 //stubbed env
+    integration = 1 //stubbed env + UC now in London
+    preprod     = 1 // UC now in London
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
 variable "k2hb_audit_london_asg_max" {
   description = "Max k2hb equality asg size. Connects to ha cluster."
   default = {
-    development = 0 //stubbed env
-    qa          = 0 //stubbed env
-    integration = 1 //stubbed env
-    preprod     = 1
-    production  = 1
+    development = 1 //stubbed env
+    qa          = 1 //stubbed env
+    integration = 1 //stubbed env + UC now in London
+    preprod     = 1 // UC now in London
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }


### PR DESCRIPTION
Flip all non-prod stacks to London - UC have moved Int and Staging/PeProd permanently now.