### PR TITLE
Small fix for the k2hb dashboards where max bax batch size is looking…

### DIFF
--- a/dashboards/kafka-to-hbase.json.tpl
+++ b/dashboards/kafka-to-hbase.json.tpl
@@ -179,7 +179,7 @@
         "metrics": [
           [
             "${namespace}",
-            "${k2hb_metric_name_number_of_successfully_processed_batches}",
+            "${k2hb_metric_name_number_of_successfully_processed_records}",
             {
               "label": "Max batch size (5m)"
             }


### PR DESCRIPTION
Small fix for the k2hb dashboards where max batch size is looking at the number of batches, rather than the size metric