### PR TITLE
Trimmed records on the k2hb dashboards as unreconciled is not a usefu…

### DIFF
--- a/dashboards/kafka-to-hbase.json.tpl
+++ b/dashboards/kafka-to-hbase.json.tpl
@@ -126,7 +126,7 @@
       "properties": {
         "metrics": [
           [
-            "${reconciliation_namespace}",
+            "${trimmer_namespace}",
             "${reconciliation_metric_name_trimmed_records}",
             {
               "label": "Trimmed metadata store records (24h)"
@@ -162,6 +162,12 @@
             "${reconciliation_metric_name_failed_to_be_reconciled}",
             {
               "label": "Unreconciled messages (5m)"
+            }
+          ],
+          [ "${trimmer_namespace}",
+            "${reconciliation_metric_name_trimmed_records}",
+            {
+              "label": "Trimmed records (5m)"
             }
           ]
         ],

--- a/dashboards/kafka-to-hbase.json.tpl
+++ b/dashboards/kafka-to-hbase.json.tpl
@@ -127,15 +127,15 @@
         "metrics": [
           [
             "${reconciliation_namespace}",
-            "${reconciliation_metric_name_failed_to_be_reconciled}",
+            "${reconciliation_metric_name_trimmed_records}",
             {
-              "label": "Unreconciled messages (24h)"
+              "label": "Trimmed metadata store records (24h)"
             }
           ]
         ],
         "view": "singleValue",
         "region": "eu-west-2",
-        "title": "Unreconciled writes (24h)",
+        "title": "Trimmed records (24h)",
         "stat": "Sum",
         "period": 86400
       }

--- a/k2hb_dashboard.tf
+++ b/k2hb_dashboard.tf
@@ -12,6 +12,7 @@ resource "aws_cloudwatch_dashboard" "k2hb" {
     k2hb_metric_name_failures_writing_hbase                      = local.k2hb_metric_name_failures_writing_hbase
     k2hb_metric_name_failed_batches                              = local.k2hb_metric_name_failed_batches
     reconciliation_metric_name_successfully_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_successfully_reconciled_records["ucfs_reconciliation"]
+    reconciliation_metric_name_failed_to_be_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_records_which_failed_reconciliation["ucfs_reconciliation"]
     reconciliation_metric_name_trimmed_records                   = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["ucfs_reconciliation"]
     number_of_unreconciled_records_after_specified_age_alarm_arn = data.terraform_remote_state.ingest.outputs.metrics.number_of_unreconciled_records_after_specified_age_alarm.ucfs.arn
 
@@ -32,6 +33,7 @@ resource "aws_cloudwatch_dashboard" "k2hb_equality" {
     k2hb_metric_name_failures_writing_hbase                      = local.k2hb_metric_name_failures_writing_hbase
     k2hb_metric_name_failed_batches                              = local.k2hb_metric_name_failed_batches
     reconciliation_metric_name_successfully_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_successfully_reconciled_records["equality_reconciliation"]
+    reconciliation_metric_name_failed_to_be_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_records_which_failed_reconciliation["equality_reconciliation"]
     reconciliation_metric_name_trimmed_records                   = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["equality_reconciliation"]
     number_of_unreconciled_records_after_specified_age_alarm_arn = data.terraform_remote_state.ingest.outputs.metrics.number_of_unreconciled_records_after_specified_age_alarm.equality.arn
 
@@ -52,6 +54,7 @@ resource "aws_cloudwatch_dashboard" "k2hb_audit" {
     k2hb_metric_name_failures_writing_hbase                      = local.k2hb_metric_name_failures_writing_hbase
     k2hb_metric_name_failed_batches                              = local.k2hb_metric_name_failed_batches
     reconciliation_metric_name_successfully_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_successfully_reconciled_records["audit_reconciliation"]
+    reconciliation_metric_name_failed_to_be_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_records_which_failed_reconciliation["audit_reconciliation"]
     reconciliation_metric_name_trimmed_records                   = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["audit_reconciliation"]
     number_of_unreconciled_records_after_specified_age_alarm_arn = data.terraform_remote_state.ingest.outputs.metrics.number_of_unreconciled_records_after_specified_age_alarm.audit.arn
 

--- a/k2hb_dashboard.tf
+++ b/k2hb_dashboard.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_dashboard" "k2hb" {
     k2hb_metric_name_failures_writing_hbase                      = local.k2hb_metric_name_failures_writing_hbase
     k2hb_metric_name_failed_batches                              = local.k2hb_metric_name_failed_batches
     reconciliation_metric_name_successfully_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_successfully_reconciled_records["ucfs_reconciliation"]
-    reconciliation_metric_name_trimmed_records           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["ucfs_reconciliation"]
+    reconciliation_metric_name_trimmed_records                   = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["ucfs_reconciliation"]
     number_of_unreconciled_records_after_specified_age_alarm_arn = data.terraform_remote_state.ingest.outputs.metrics.number_of_unreconciled_records_after_specified_age_alarm.ucfs.arn
 
   })
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_dashboard" "k2hb_equality" {
     k2hb_metric_name_failures_writing_hbase                      = local.k2hb_metric_name_failures_writing_hbase
     k2hb_metric_name_failed_batches                              = local.k2hb_metric_name_failed_batches
     reconciliation_metric_name_successfully_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_successfully_reconciled_records["equality_reconciliation"]
-    reconciliation_metric_name_trimmed_records           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["equality_reconciliation"]
+    reconciliation_metric_name_trimmed_records                   = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["equality_reconciliation"]
     number_of_unreconciled_records_after_specified_age_alarm_arn = data.terraform_remote_state.ingest.outputs.metrics.number_of_unreconciled_records_after_specified_age_alarm.equality.arn
 
   })
@@ -52,7 +52,7 @@ resource "aws_cloudwatch_dashboard" "k2hb_audit" {
     k2hb_metric_name_failures_writing_hbase                      = local.k2hb_metric_name_failures_writing_hbase
     k2hb_metric_name_failed_batches                              = local.k2hb_metric_name_failed_batches
     reconciliation_metric_name_successfully_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_successfully_reconciled_records["audit_reconciliation"]
-    reconciliation_metric_name_trimmed_records           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["audit_reconciliation"]
+    reconciliation_metric_name_trimmed_records                   = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["audit_reconciliation"]
     number_of_unreconciled_records_after_specified_age_alarm_arn = data.terraform_remote_state.ingest.outputs.metrics.number_of_unreconciled_records_after_specified_age_alarm.audit.arn
 
   })

--- a/k2hb_dashboard.tf
+++ b/k2hb_dashboard.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_dashboard" "k2hb" {
     k2hb_metric_name_failures_writing_hbase                      = local.k2hb_metric_name_failures_writing_hbase
     k2hb_metric_name_failed_batches                              = local.k2hb_metric_name_failed_batches
     reconciliation_metric_name_successfully_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_successfully_reconciled_records["ucfs_reconciliation"]
-    reconciliation_metric_name_failed_to_be_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_records_which_failed_reconciliation["ucfs_reconciliation"]
+    reconciliation_metric_name_trimmed_records           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["ucfs_reconciliation"]
     number_of_unreconciled_records_after_specified_age_alarm_arn = data.terraform_remote_state.ingest.outputs.metrics.number_of_unreconciled_records_after_specified_age_alarm.ucfs.arn
 
   })
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_dashboard" "k2hb_equality" {
     k2hb_metric_name_failures_writing_hbase                      = local.k2hb_metric_name_failures_writing_hbase
     k2hb_metric_name_failed_batches                              = local.k2hb_metric_name_failed_batches
     reconciliation_metric_name_successfully_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_successfully_reconciled_records["equality_reconciliation"]
-    reconciliation_metric_name_failed_to_be_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_records_which_failed_reconciliation["equality_reconciliation"]
+    reconciliation_metric_name_trimmed_records           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["equality_reconciliation"]
     number_of_unreconciled_records_after_specified_age_alarm_arn = data.terraform_remote_state.ingest.outputs.metrics.number_of_unreconciled_records_after_specified_age_alarm.equality.arn
 
   })
@@ -52,7 +52,7 @@ resource "aws_cloudwatch_dashboard" "k2hb_audit" {
     k2hb_metric_name_failures_writing_hbase                      = local.k2hb_metric_name_failures_writing_hbase
     k2hb_metric_name_failed_batches                              = local.k2hb_metric_name_failed_batches
     reconciliation_metric_name_successfully_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_successfully_reconciled_records["audit_reconciliation"]
-    reconciliation_metric_name_failed_to_be_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_records_which_failed_reconciliation["audit_reconciliation"]
+    reconciliation_metric_name_trimmed_records           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["audit_reconciliation"]
     number_of_unreconciled_records_after_specified_age_alarm_arn = data.terraform_remote_state.ingest.outputs.metrics.number_of_unreconciled_records_after_specified_age_alarm.audit.arn
 
   })

--- a/k2hb_dashboard.tf
+++ b/k2hb_dashboard.tf
@@ -3,6 +3,7 @@ resource "aws_cloudwatch_dashboard" "k2hb" {
   dashboard_body = templatefile("${path.module}/dashboards/kafka-to-hbase.json.tpl", {
     namespace                                                    = local.cw_k2hb_main_agent_namespace
     reconciliation_namespace                                     = data.terraform_remote_state.ingest.outputs.locals.cw_k2hb_reconciliation_ucfs_namespace
+    trimmer_namespace                                            = data.terraform_remote_state.ingest.outputs.locals.cw_k2hb_reconciliation_trimmer_namespace["ucfs_reconciliation"]
     log_group                                                    = local.ingest_log_groups.k2hb_ec2_logs.name
     k2hb_metric_name_number_of_successfully_processed_records    = local.k2hb_metric_name_number_of_successfully_processed_records
     k2hb_metric_name_speed_of_successfully_processed_batches     = local.k2hb_metric_name_speed_of_successfully_processed_batches
@@ -24,6 +25,7 @@ resource "aws_cloudwatch_dashboard" "k2hb_equality" {
   dashboard_body = templatefile("${path.module}/dashboards/kafka-to-hbase.json.tpl", {
     namespace                                                    = local.cw_k2hb_equality_agent_namespace
     reconciliation_namespace                                     = data.terraform_remote_state.ingest.outputs.locals.cw_k2hb_reconciliation_equality_namespace
+    trimmer_namespace                                            = data.terraform_remote_state.ingest.outputs.locals.cw_k2hb_reconciliation_trimmer_namespace["equality_reconciliation"]
     log_group                                                    = local.ingest_log_groups.k2hb_ec2_equality_logs.name
     k2hb_metric_name_number_of_successfully_processed_records    = local.k2hb_metric_name_number_of_successfully_processed_records
     k2hb_metric_name_speed_of_successfully_processed_batches     = local.k2hb_metric_name_speed_of_successfully_processed_batches
@@ -45,6 +47,7 @@ resource "aws_cloudwatch_dashboard" "k2hb_audit" {
   dashboard_body = templatefile("${path.module}/dashboards/kafka-to-hbase.json.tpl", {
     namespace                                                    = local.cw_k2hb_audit_agent_namespace
     reconciliation_namespace                                     = data.terraform_remote_state.ingest.outputs.locals.cw_k2hb_reconciliation_audit_namespace
+    trimmer_namespace                                            = data.terraform_remote_state.ingest.outputs.locals.cw_k2hb_reconciliation_trimmer_namespace["audit_reconciliation"]
     log_group                                                    = local.k2hb_ec2_audit_logs_name
     k2hb_metric_name_number_of_successfully_processed_records    = local.k2hb_metric_name_number_of_successfully_processed_records
     k2hb_metric_name_speed_of_successfully_processed_batches     = local.k2hb_metric_name_speed_of_successfully_processed_batches


### PR DESCRIPTION
Trimmed records on the k2hb dashboards onciled is not a useful count to see as it's the alert that matters not a sum of unreconciled records