### PR TITLE
Switch to London - prepare pr in advance of the day

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -245,7 +245,7 @@ variable "k2hb_audit_london_asg_desired" {
     qa          = 1 //stubbed env
     integration = 1 //stubbed env + UC now in London
     preprod     = 1 // UC now in London
-    production  = 20 // Switch to London on 21 Nov 2020
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -256,6 +256,6 @@ variable "k2hb_audit_london_asg_max" {
     qa          = 1 //stubbed env
     integration = 1 //stubbed env + UC now in London
     preprod     = 1 // UC now in London
-    production  = 20 // Switch to London on 21 Nov 2020
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "k2hb_audit_ec2_size" {
     qa          = "t3.medium"
     integration = "t3.medium"
     preprod     = "t3.medium"
-    production  = "c5.large"
+    production  = "c5.xlarge"
   }
 }
 
@@ -80,7 +80,7 @@ variable "k2hb_audit_max_memory_allocation" {
     qa          = "-Xmx1g"
     integration = "-Xmx1g"
     preprod     = "-Xmx1g"
-    production  = "-Xmx2g"
+    production  = "-Xmx4g"
   }
 }
 
@@ -91,7 +91,7 @@ variable "k2hb_main_ireland_asg_desired" {
     qa          = 0  //stubbed env
     integration = 0  //stubbed env and UC now in London
     preprod     = 0  // UC now in London
-    production  = 21 // Switch to London on 21 Nov 2020
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -102,7 +102,7 @@ variable "k2hb_main_ireland_asg_max" {
     qa          = 0  //stubbed env
     integration = 0  //stubbed env and now in London
     preprod     = 0  // UC now in London
-    production  = 21 // Switch to London on 21 Nov 2020
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -113,7 +113,7 @@ variable "k2hb_main_dedicated_ireland_asg_desired" {
     qa          = 0  //stubbed env
     integration = 0  //stubbed env and UC now in London
     preprod     = 0  // UC now in London
-    production  = 21 // Switch to London on 21 Nov 2020
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -124,7 +124,7 @@ variable "k2hb_main_dedicated_ireland_asg_max" {
     qa          = 0  //stubbed env
     integration = 0  //stubbed env and now in London
     preprod     = 0  // UC now in London
-    production  = 21 // Switch to London on 21 Nov 2020
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -135,7 +135,7 @@ variable "k2hb_main_london_asg_desired" {
     qa          = 2 //stubbed env
     integration = 2 //stubbed env + UC now in London
     preprod     = 2 // UC now in London
-    production  = 0 // Switch to London on 21 Nov 2020
+    production  = 20 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -146,7 +146,7 @@ variable "k2hb_main_london_asg_max" {
     qa          = 2 //stubbed env
     integration = 2 //stubbed env
     preprod     = 2 // UC now in London
-    production  = 0 // Switch to London on 21 Nov 2020
+    production  = 20 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -157,7 +157,7 @@ variable "k2hb_main_dedicated_london_asg_desired" {
     qa          = 1 //stubbed env
     integration = 1 //stubbed env + UC now in London
     preprod     = 2 // UC now in London
-    production  = 0 // Switch to London on 21 Nov 2020
+    production  = 20 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -168,7 +168,7 @@ variable "k2hb_main_dedicated_london_asg_max" {
     qa          = 1 //stubbed env
     integration = 1 //stubbed env
     preprod     = 2 // UC now in London
-    production  = 0 // Switch to London on 21 Nov 2020
+    production  = 20 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -179,7 +179,7 @@ variable "k2hb_equality_ireland_asg_desired" {
     qa          = 0 //stubbed env
     integration = 0 //stubbed env and now in London
     preprod     = 0 // UC now in London
-    production  = 1 // Switch to London on 21 Nov 2020
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -190,7 +190,7 @@ variable "k2hb_equality_ireland_asg_max" {
     qa          = 0 //stubbed env
     integration = 0 //stubbed env and now in London
     preprod     = 0 // UC now in London
-    production  = 1 // Switch to London on 21 Nov 2020
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -201,7 +201,7 @@ variable "k2hb_equality_london_asg_desired" {
     qa          = 1 //stubbed env
     integration = 1 //stubbed env + UC now in London
     preprod     = 1 // UC now in London
-    production  = 0 // Switch to London on 21 Nov 2020
+    production  = 1 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -212,7 +212,7 @@ variable "k2hb_equality_london_asg_max" {
     qa          = 1 //stubbed env
     integration = 1 //stubbed env + UC now in London
     preprod     = 1 // UC now in London
-    production  = 0 // Switch to London on 21 Nov 2020
+    production  = 1 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -223,7 +223,7 @@ variable "k2hb_audit_ireland_asg_desired" {
     qa          = 0  //stubbed env
     integration = 0  //stubbed env + UC now in London
     preprod     = 0  // UC now in London
-    production  = 21 // Switch to London on 21 Nov 2020
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -234,7 +234,7 @@ variable "k2hb_audit_ireland_asg_max" {
     qa          = 0  //stubbed env
     integration = 0  //stubbed env + UC now in London
     preprod     = 0  // UC now in London
-    production  = 21 // Switch to London on 21 Nov 2020
+    production  = 0 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -245,7 +245,7 @@ variable "k2hb_audit_london_asg_desired" {
     qa          = 1 //stubbed env
     integration = 1 //stubbed env + UC now in London
     preprod     = 1 // UC now in London
-    production  = 0 // Switch to London on 21 Nov 2020
+    production  = 20 // Switch to London on 21 Nov 2020
   }
 }
 
@@ -256,6 +256,6 @@ variable "k2hb_audit_london_asg_max" {
     qa          = 1 //stubbed env
     integration = 1 //stubbed env + UC now in London
     preprod     = 1 // UC now in London
-    production  = 0 // Switch to London on 21 Nov 2020
+    production  = 20 // Switch to London on 21 Nov 2020
   }
 }


### PR DESCRIPTION
Switch to London - prepare pr in advance of the day.
Temporarily scale back up to 20 workers to clear any backlog. Will go back to 10s or 15s when the dust settles.
NOT TO BE MERGED TILL SAT 21ST and after UC flip the services and we've drained the old ones.