### PR TITLE
Increase threshold

### DIFF
--- a/dashboards/kafka-to-hbase.json.tpl
+++ b/dashboards/kafka-to-hbase.json.tpl
@@ -325,7 +325,7 @@
       "type": "metric",
       "x": 0,
       "y": 33,
-      "width": 12,
+      "width": 24,
       "height": 6,
       "properties": {
         "metrics": [
@@ -349,24 +349,6 @@
             "showUnits": false
           }
         }
-      }
-    },
-    {
-      "type": "metric",
-      "x": 12,
-      "y": 33,
-      "width": 12,
-      "height": 6,
-      "properties": {
-        "title": "Unreconciled records after specified age",
-        "annotations": {
-          "alarms": [
-              "${number_of_unreconciled_records_after_specified_age_alarm_arn}"
-          ]
-        },
-        "view": "bar",
-        "stacked": true,
-        "type": "chart"
       }
     },
     {

--- a/k2hb_dashboard.tf
+++ b/k2hb_dashboard.tf
@@ -15,7 +15,6 @@ resource "aws_cloudwatch_dashboard" "k2hb" {
     reconciliation_metric_name_successfully_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_successfully_reconciled_records["ucfs_reconciliation"]
     reconciliation_metric_name_failed_to_be_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_records_which_failed_reconciliation["ucfs_reconciliation"]
     reconciliation_metric_name_trimmed_records                   = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["ucfs_reconciliation"]
-    number_of_unreconciled_records_after_specified_age_alarm_arn = data.terraform_remote_state.ingest.outputs.metrics.number_of_unreconciled_records_after_specified_age_alarm.ucfs.arn
     k2hb_metric_name_lag_per_partition                           = local.k2hb_metric_name_lag_per_partition
   })
 }
@@ -37,7 +36,6 @@ resource "aws_cloudwatch_dashboard" "k2hb_equality" {
     reconciliation_metric_name_successfully_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_successfully_reconciled_records["equality_reconciliation"]
     reconciliation_metric_name_failed_to_be_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_records_which_failed_reconciliation["equality_reconciliation"]
     reconciliation_metric_name_trimmed_records                   = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["equality_reconciliation"]
-    number_of_unreconciled_records_after_specified_age_alarm_arn = data.terraform_remote_state.ingest.outputs.metrics.number_of_unreconciled_records_after_specified_age_alarm.equality.arn
     k2hb_metric_name_lag_per_partition                           = local.k2hb_metric_name_lag_per_partition
   })
 }
@@ -59,7 +57,6 @@ resource "aws_cloudwatch_dashboard" "k2hb_audit" {
     reconciliation_metric_name_successfully_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_successfully_reconciled_records["audit_reconciliation"]
     reconciliation_metric_name_failed_to_be_reconciled           = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_metric_name_number_of_records_which_failed_reconciliation["audit_reconciliation"]
     reconciliation_metric_name_trimmed_records                   = data.terraform_remote_state.ingest.outputs.locals.k2hb_reconciliation_trimmer_metric_name_number_of_records_which_have_been_trimmed["audit_reconciliation"]
-    number_of_unreconciled_records_after_specified_age_alarm_arn = data.terraform_remote_state.ingest.outputs.metrics.number_of_unreconciled_records_after_specified_age_alarm.audit.arn
     k2hb_metric_name_lag_per_partition                           = local.k2hb_metric_name_lag_per_partition
   })
 }

--- a/k2hb_monitoring_audit.tf
+++ b/k2hb_monitoring_audit.tf
@@ -34,88 +34,148 @@ resource "aws_cloudwatch_log_metric_filter" "time_to_process_batch_filter_k2hb_a
   }
 }
 
-module "rate_of_dlq_messages_written_filter_k2hb_alarm_audit" {
-  count = local.k2hb_alarm_on_dlq_audit[local.environment] ? 1 : 0
-  source  = "dwp/metric-filter-alarm/aws"
-  version = "1.1.7"
+resource "aws_cloudwatch_log_metric_filter" "rate_of_dlq_messages_written_audit" {
+  log_group_name = local.k2hb_ec2_audit_logs_name
+  name           = local.k2hb_metric_name_messages_written_to_dlq
+  pattern        = "{ $.message = \"Error processing record, sending to dlq\" }"
 
-  log_group_name      = local.k2hb_ec2_audit_logs_name
-  metric_namespace    = local.cw_k2hb_audit_agent_namespace
-  pattern             = "{ $.message = \"Error processing record, sending to dlq\" }"
+  metric_transformation {
+    name      = local.k2hb_metric_name_messages_written_to_dlq
+    namespace = local.cw_k2hb_audit_agent_namespace
+    value     = 1
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rate_of_dlq_messages_written_audit" {
+  count = local.k2hb_alarm_on_dlq_audit[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.rate_of_dlq_messages_written_audit.name
+
+  namespace           = local.cw_k2hb_audit_agent_namespace
   alarm_name          = "K2HB audit - Messages written to DLQ in last half an hour"
   alarm_description   = "Managed by ${local.common_tags.Application} repository"
-  metric_filter_name  = local.k2hb_metric_name_messages_written_to_dlq
-  alarm_action_arns   = [local.monitoring_topic_arn]
+  alarm_actions       = [local.monitoring_topic_arn]
   evaluation_periods  = 1
   period              = 1800
   threshold           = 0
   statistic           = "Sum"
   comparison_operator = "GreaterThanThreshold"
-  severity            = "Warning"
-  notification_type   = "High"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "dlq-written-rate-alarm-audit",
+      notification_type = "Warning",
+      severity          = "High"
+    },
+  )
 }
 
-module "kafka_read_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_audit" {
-  count = local.k2hb_alarm_on_kafka_read_timeouts_audit[local.environment] ? 1 : 0
-  source  = "dwp/metric-filter-alarm/aws"
-  version = "1.1.7"
+resource "aws_cloudwatch_log_metric_filter" "kafka_read_timeout_audit" {
+  log_group_name = local.k2hb_ec2_audit_logs_name
+  name           = local.k2hb_metric_name_timeouts_reading_kafka
+  pattern        = "{ $.message = \"Error reading from Kafka\" }"
 
-  log_group_name      = local.k2hb_ec2_audit_logs_name
-  metric_namespace    = local.cw_k2hb_audit_agent_namespace
-  pattern             = "{ $.message = \"Error reading from Kafka\" }"
+  metric_transformation {
+    name      = local.k2hb_metric_name_timeouts_reading_kafka
+    namespace = local.cw_k2hb_audit_agent_namespace
+    value     = 1
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "kafka_read_timeout_audit" {
+  count = local.k2hb_alarm_on_kafka_read_timeouts_audit[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.kafka_read_timeout_audit.name
+
+  namespace           = local.cw_k2hb_audit_agent_namespace
   alarm_name          = "K2HB audit - Kafka read timeout occurrences exceeds 5 in last hour"
   alarm_description   = "Managed by ${local.common_tags.Application} repository"
-  metric_filter_name  = local.k2hb_metric_name_timeouts_reading_kafka
-  alarm_action_arns   = [local.monitoring_topic_arn]
+  alarm_actions       = [local.monitoring_topic_arn]
   evaluation_periods  = 1
   period              = 3600
   threshold           = 5
   statistic           = "Sum"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  severity            = "Warning"
-  notification_type   = "High"
+  comparison_operator = "GreaterThanThreshold"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "kafka-read-timeouts-audit",
+      notification_type = "Warning",
+      severity          = "High"
+    },
+  )
 }
 
-module "hbase_batch_failures_greater_than_threshold_filter_k2hb_alarm_audit" {
+resource "aws_cloudwatch_log_metric_filter" "kafka_write_timeout_audit" {
+  log_group_name = local.k2hb_ec2_audit_logs_name
+  name           = local.k2hb_metric_name_failures_writing_hbase
+  pattern        = "{ $.message = \"Failed to put batch into hbase\"}"
+
+  metric_transformation {
+    name      = local.k2hb_metric_name_failures_writing_hbase
+    namespace = local.cw_k2hb_audit_agent_namespace
+    value     = 1
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "kafka_write_timeout_audit" {
   count = local.k2hb_alarm_on_hbase_write_timeouts_audit[local.environment] ? 1 : 0
-  source  = "dwp/metric-filter-alarm/aws"
-  version = "1.1.7"
+  metric_name = aws_cloudwatch_log_metric_filter.kafka_write_timeout_audit.name
 
-  log_group_name      = local.k2hb_ec2_audit_logs_name
-  metric_namespace    = local.cw_k2hb_audit_agent_namespace
-  pattern             = "{ $.message = \"Failed to put batch into hbase\"}"
-  alarm_name          = "K2HB audit - Hbase write failures exceeds 5 in last hour"
+  namespace           = local.cw_k2hb_audit_agent_namespace
+  alarm_name          = "K2HB audit - Kafka write failures exceeds 5 in last hour"
   alarm_description   = "Managed by ${local.common_tags.Application} repository"
-  metric_filter_name  = local.k2hb_metric_name_failures_writing_hbase
-  alarm_action_arns   = [local.monitoring_topic_arn]
+  alarm_actions       = [local.monitoring_topic_arn]
   evaluation_periods  = 1
   period              = 3600
   threshold           = 5
   statistic           = "Sum"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  severity            = "Warning"
-  notification_type   = "High"
+  comparison_operator = "GreaterThanThreshold"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "kafka-write-timeouts-audit",
+      notification_type = "Warning",
+      severity          = "High"
+    },
+  )
 }
 
-module "hbase_connection_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_audit" {
-  count = local.k2hb_alarm_on_hbase_connection_timeouts_audit[local.environment] ? 1 : 0
-  source  = "dwp/metric-filter-alarm/aws"
-  version = "1.1.7"
+resource "aws_cloudwatch_log_metric_filter" "kafka_connection_timeout_audit" {
+  log_group_name = local.k2hb_ec2_audit_logs_name
+  name           = local.k2hb_metric_name_timeouts_connecting_hbase
+  pattern        = "{ $.message = \"Error connecting to Hbase\" }"
 
-  log_group_name      = local.k2hb_ec2_audit_logs_name
-  metric_namespace    = local.cw_k2hb_audit_agent_namespace
-  pattern             = "{ $.message = \"Error connecting to Hbase\" }"
-  alarm_name          = "K2HB audit - Hbase connection timeout occurrences exceeds 5 in last hour"
+  metric_transformation {
+    name      = local.k2hb_metric_name_timeouts_connecting_hbase
+    namespace = local.cw_k2hb_audit_agent_namespace
+    value     = 1
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "kafka_connection_timeout_audit" {
+  count = local.k2hb_alarm_on_hbase_connection_timeouts_audit[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.kafka_connection_timeout_audit.name
+
+  namespace           = local.cw_k2hb_audit_agent_namespace
+  alarm_name          = "K2HB audit - Kafka connection failures exceeds 5 in last hour"
   alarm_description   = "Managed by ${local.common_tags.Application} repository"
-  metric_filter_name  = local.k2hb_metric_name_timeouts_connecting_hbase
-  alarm_action_arns   = [local.monitoring_topic_arn]
+  alarm_actions       = [local.monitoring_topic_arn]
   evaluation_periods  = 1
   period              = 3600
   threshold           = 5
   statistic           = "Sum"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  severity            = "Warning"
-  notification_type   = "High"
+  comparison_operator = "GreaterThanThreshold"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "kafka-connection-timeouts-audit",
+      notification_type = "Warning",
+      severity          = "High"
+    },
+  )
 }
 
 resource "aws_cloudwatch_log_metric_filter" "consumer_lag_k2hb_audit" {

--- a/k2hb_monitoring_audit.tf
+++ b/k2hb_monitoring_audit.tf
@@ -118,30 +118,6 @@ resource "aws_cloudwatch_log_metric_filter" "kafka_write_timeout_audit" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "kafka_write_timeout_audit" {
-  count = local.k2hb_alarm_on_hbase_write_timeouts_audit[local.environment] ? 1 : 0
-  metric_name = aws_cloudwatch_log_metric_filter.kafka_write_timeout_audit.name
-
-  namespace           = local.cw_k2hb_audit_agent_namespace
-  alarm_name          = "K2HB audit - Kafka write failures exceeds 5 in last hour"
-  alarm_description   = "Managed by ${local.common_tags.Application} repository"
-  alarm_actions       = [local.monitoring_topic_arn]
-  evaluation_periods  = 1
-  period              = 3600
-  threshold           = 5
-  statistic           = "Sum"
-  comparison_operator = "GreaterThanThreshold"
-
-  tags = merge(
-    local.common_tags,
-    {
-      Name              = "kafka-write-timeouts-audit",
-      notification_type = "Warning",
-      severity          = "High"
-    },
-  )
-}
-
 resource "aws_cloudwatch_log_metric_filter" "kafka_connection_timeout_audit" {
   log_group_name = local.k2hb_ec2_audit_logs_name
   name           = local.k2hb_metric_name_timeouts_connecting_hbase
@@ -232,13 +208,13 @@ resource "aws_cloudwatch_metric_alarm" "failed_k2hb_batches_exceeds_threshold_au
   metric_name = aws_cloudwatch_log_metric_filter.failed_k2hb_batches_audit.name
 
   namespace           = local.cw_k2hb_audit_agent_namespace
-  alarm_name          = "K2HB audit - Failed batches exceeds 5 in last 30 minutes"
+  alarm_name          = "K2HB audit - Failed batches exceeds 50 in last 30 minutes"
   alarm_description   = "Managed by ${local.common_tags.Application} repository"
   alarm_actions       = [local.monitoring_topic_arn]
   evaluation_periods  = 1
   period              = 1800
   datapoints_to_alarm = 1
-  threshold           = 5
+  threshold           = 50
   statistic           = "Sum"
   comparison_operator = "GreaterThanOrEqualToThreshold"
 

--- a/k2hb_monitoring_audit.tf
+++ b/k2hb_monitoring_audit.tf
@@ -35,6 +35,7 @@ resource "aws_cloudwatch_log_metric_filter" "time_to_process_batch_filter_k2hb_a
 }
 
 module "rate_of_dlq_messages_written_filter_k2hb_alarm_audit" {
+  count = local.k2hb_alarm_on_dlq_audit[local.environment] ? 1 : 0
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.7"
 
@@ -55,6 +56,7 @@ module "rate_of_dlq_messages_written_filter_k2hb_alarm_audit" {
 }
 
 module "kafka_read_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_audit" {
+  count = local.k2hb_alarm_on_kafka_read_timeouts_audit[local.environment] ? 1 : 0
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.7"
 
@@ -75,6 +77,7 @@ module "kafka_read_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_
 }
 
 module "hbase_batch_failures_greater_than_threshold_filter_k2hb_alarm_audit" {
+  count = local.k2hb_alarm_on_hbase_write_timeouts_audit[local.environment] ? 1 : 0
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.7"
 
@@ -95,6 +98,7 @@ module "hbase_batch_failures_greater_than_threshold_filter_k2hb_alarm_audit" {
 }
 
 module "hbase_connection_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_audit" {
+  count = local.k2hb_alarm_on_hbase_connection_timeouts_audit[local.environment] ? 1 : 0
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.7"
 
@@ -127,6 +131,7 @@ resource "aws_cloudwatch_log_metric_filter" "consumer_lag_k2hb_audit" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "consumer_lag_k2hb_alarm_audit" {
+  count = local.k2hb_alarm_on_consumer_lag_audit[local.environment] ? 1 : 0
   metric_name = aws_cloudwatch_log_metric_filter.consumer_lag_k2hb_audit.name
 
   namespace           = local.cw_k2hb_audit_agent_namespace
@@ -163,6 +168,7 @@ resource "aws_cloudwatch_log_metric_filter" "failed_k2hb_batches_audit" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "failed_k2hb_batches_exceeds_threshold_audit" {
+  count = local.k2hb_alarm_on_failed_batches_audit[local.environment] ? 1 : 0
   metric_name = aws_cloudwatch_log_metric_filter.failed_k2hb_batches_audit.name
 
   namespace           = local.cw_k2hb_audit_agent_namespace

--- a/k2hb_monitoring_equality.tf
+++ b/k2hb_monitoring_equality.tf
@@ -34,88 +34,148 @@ resource "aws_cloudwatch_log_metric_filter" "time_to_process_batch_filter_k2hb_e
   }
 }
 
-module "rate_of_dlq_messages_written_filter_k2hb_alarm_equalities" {
-  count = local.k2hb_alarm_on_dlq_equalities[local.environment] ? 1 : 0
-  source  = "dwp/metric-filter-alarm/aws"
-  version = "1.1.7"
+resource "aws_cloudwatch_log_metric_filter" "rate_of_dlq_messages_written_equalities" {
+  log_group_name = local.k2hb_ec2_equality_logs_name
+  name           = local.k2hb_metric_name_messages_written_to_dlq
+  pattern        = "{ $.message = \"Error processing record, sending to dlq\" }"
 
-  log_group_name      = local.k2hb_ec2_equality_logs_name
-  metric_namespace    = local.cw_k2hb_equality_agent_namespace
-  pattern             = "{ $.message = \"Error processing record, sending to dlq\" }"
+  metric_transformation {
+    name      = local.k2hb_metric_name_messages_written_to_dlq
+    namespace = local.cw_k2hb_equality_agent_namespace
+    value     = 1
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rate_of_dlq_messages_written_equalities" {
+  count = local.k2hb_alarm_on_dlq_equalities[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.rate_of_dlq_messages_written_equalities.name
+
+  namespace           = local.cw_k2hb_equality_agent_namespace
   alarm_name          = "K2HB equalities - Messages written to DLQ in last half an hour"
   alarm_description   = "Managed by ${local.common_tags.Application} repository"
-  metric_filter_name  = local.k2hb_metric_name_messages_written_to_dlq
-  alarm_action_arns   = [local.monitoring_topic_arn]
+  alarm_actions       = [local.monitoring_topic_arn]
   evaluation_periods  = 1
   period              = 1800
   threshold           = 0
   statistic           = "Sum"
   comparison_operator = "GreaterThanThreshold"
-  severity            = "Warning"
-  notification_type   = "High"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "dlq-written-rate-alarm-equalities",
+      notification_type = "Warning",
+      severity          = "High"
+    },
+  )
 }
 
-module "kafka_read_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_equalities" {
-  count = local.k2hb_alarm_on_kafka_read_timeouts_equalities[local.environment] ? 1 : 0
-  source  = "dwp/metric-filter-alarm/aws"
-  version = "1.1.7"
+resource "aws_cloudwatch_log_metric_filter" "kafka_read_timeout_equalities" {
+  log_group_name = local.k2hb_ec2_equality_logs_name
+  name           = local.k2hb_metric_name_timeouts_reading_kafka
+  pattern        = "{ $.message = \"Error reading from Kafka\" }"
 
-  log_group_name      = local.k2hb_ec2_equality_logs_name
-  metric_namespace    = local.cw_k2hb_equality_agent_namespace
-  pattern             = "{ $.message = \"Error reading from Kafka\" }"
+  metric_transformation {
+    name      = local.k2hb_metric_name_timeouts_reading_kafka
+    namespace = local.cw_k2hb_equality_agent_namespace
+    value     = 1
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "kafka_read_timeout_equalities" {
+  count = local.k2hb_alarm_on_kafka_read_timeouts_equalities[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.kafka_read_timeout_equalities.name
+
+  namespace           = local.cw_k2hb_equality_agent_namespace
   alarm_name          = "K2HB equalities - Kafka read timeout occurrences exceeds 5 in last hour"
   alarm_description   = "Managed by ${local.common_tags.Application} repository"
-  metric_filter_name  = local.k2hb_metric_name_timeouts_reading_kafka
-  alarm_action_arns   = [local.monitoring_topic_arn]
+  alarm_actions       = [local.monitoring_topic_arn]
   evaluation_periods  = 1
   period              = 3600
   threshold           = 5
   statistic           = "Sum"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  severity            = "Warning"
-  notification_type   = "High"
+  comparison_operator = "GreaterThanThreshold"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "kafka-read-timeouts-equalities",
+      notification_type = "Warning",
+      severity          = "High"
+    },
+  )
 }
 
-module "hbase_batch_failures_greater_than_threshold_filter_k2hb_alarm_equalities" {
+resource "aws_cloudwatch_log_metric_filter" "kafka_write_timeout_equalities" {
+  log_group_name = local.k2hb_ec2_equality_logs_name
+  name           = local.k2hb_metric_name_failures_writing_hbase
+  pattern        = "{ $.message = \"Failed to put batch into hbase\"}"
+
+  metric_transformation {
+    name      = local.k2hb_metric_name_failures_writing_hbase
+    namespace = local.cw_k2hb_equality_agent_namespace
+    value     = 1
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "kafka_write_timeout_equalities" {
   count = local.k2hb_alarm_on_hbase_write_timeouts_equalities[local.environment] ? 1 : 0
-  source  = "dwp/metric-filter-alarm/aws"
-  version = "1.1.7"
+  metric_name = aws_cloudwatch_log_metric_filter.kafka_write_timeout_equalities.name
 
-  log_group_name      = local.k2hb_ec2_equality_logs_name
-  metric_namespace    = local.cw_k2hb_equality_agent_namespace
-  pattern             = "{ $.message = \"Failed to put batch into hbase\"}"
-  alarm_name          = "K2HB equalities - Hbase write failures exceeds 5 in last hour"
+  namespace           = local.cw_k2hb_equality_agent_namespace
+  alarm_name          = "K2HB equalities - Kafka write failures exceeds 5 in last hour"
   alarm_description   = "Managed by ${local.common_tags.Application} repository"
-  metric_filter_name  = local.k2hb_metric_name_failures_writing_hbase
-  alarm_action_arns   = [local.monitoring_topic_arn]
+  alarm_actions       = [local.monitoring_topic_arn]
   evaluation_periods  = 1
   period              = 3600
   threshold           = 5
   statistic           = "Sum"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  severity            = "Warning"
-  notification_type   = "High"
+  comparison_operator = "GreaterThanThreshold"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "kafka-write-timeouts-equalities",
+      notification_type = "Warning",
+      severity          = "High"
+    },
+  )
 }
 
-module "hbase_connection_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_equalities" {
-  count = local.k2hb_alarm_on_hbase_connection_timeouts_equalities[local.environment] ? 1 : 0
-  source  = "dwp/metric-filter-alarm/aws"
-  version = "1.1.7"
+resource "aws_cloudwatch_log_metric_filter" "kafka_connection_timeout_equalities" {
+  log_group_name = local.k2hb_ec2_equality_logs_name
+  name           = local.k2hb_metric_name_timeouts_connecting_hbase
+  pattern        = "{ $.message = \"Error connecting to Hbase\" }"
 
-  log_group_name      = local.k2hb_ec2_equality_logs_name
-  metric_namespace    = local.cw_k2hb_equality_agent_namespace
-  pattern             = "{ $.message = \"Error connecting to Hbase\" }"
-  alarm_name          = "K2HB equalities - Hbase connection timeout occurrences exceeds 5 in last hour"
+  metric_transformation {
+    name      = local.k2hb_metric_name_timeouts_connecting_hbase
+    namespace = local.cw_k2hb_equality_agent_namespace
+    value     = 1
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "kafka_connection_timeout_equalities" {
+  count = local.k2hb_alarm_on_hbase_connection_timeouts_equalities[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.kafka_connection_timeout_equalities.name
+
+  namespace           = local.cw_k2hb_equality_agent_namespace
+  alarm_name          = "K2HB equalities - Kafka connection failures exceeds 5 in last hour"
   alarm_description   = "Managed by ${local.common_tags.Application} repository"
-  metric_filter_name  = local.k2hb_metric_name_timeouts_connecting_hbase
-  alarm_action_arns   = [local.monitoring_topic_arn]
+  alarm_actions       = [local.monitoring_topic_arn]
   evaluation_periods  = 1
   period              = 3600
   threshold           = 5
   statistic           = "Sum"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  severity            = "Warning"
-  notification_type   = "High"
+  comparison_operator = "GreaterThanThreshold"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "kafka-connection-timeouts-equalities",
+      notification_type = "Warning",
+      severity          = "High"
+    },
+  )
 }
 
 resource "aws_cloudwatch_log_metric_filter" "consumer_lag_k2hb_equalities" {

--- a/k2hb_monitoring_equality.tf
+++ b/k2hb_monitoring_equality.tf
@@ -118,30 +118,6 @@ resource "aws_cloudwatch_log_metric_filter" "kafka_write_timeout_equalities" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "kafka_write_timeout_equalities" {
-  count = local.k2hb_alarm_on_hbase_write_timeouts_equalities[local.environment] ? 1 : 0
-  metric_name = aws_cloudwatch_log_metric_filter.kafka_write_timeout_equalities.name
-
-  namespace           = local.cw_k2hb_equality_agent_namespace
-  alarm_name          = "K2HB equalities - Kafka write failures exceeds 5 in last hour"
-  alarm_description   = "Managed by ${local.common_tags.Application} repository"
-  alarm_actions       = [local.monitoring_topic_arn]
-  evaluation_periods  = 1
-  period              = 3600
-  threshold           = 5
-  statistic           = "Sum"
-  comparison_operator = "GreaterThanThreshold"
-
-  tags = merge(
-    local.common_tags,
-    {
-      Name              = "kafka-write-timeouts-equalities",
-      notification_type = "Warning",
-      severity          = "High"
-    },
-  )
-}
-
 resource "aws_cloudwatch_log_metric_filter" "kafka_connection_timeout_equalities" {
   log_group_name = local.k2hb_ec2_equality_logs_name
   name           = local.k2hb_metric_name_timeouts_connecting_hbase

--- a/k2hb_monitoring_equality.tf
+++ b/k2hb_monitoring_equality.tf
@@ -35,6 +35,7 @@ resource "aws_cloudwatch_log_metric_filter" "time_to_process_batch_filter_k2hb_e
 }
 
 module "rate_of_dlq_messages_written_filter_k2hb_alarm_equalities" {
+  count = local.k2hb_alarm_on_dlq_equalities[local.environment] ? 1 : 0
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.7"
 
@@ -55,6 +56,7 @@ module "rate_of_dlq_messages_written_filter_k2hb_alarm_equalities" {
 }
 
 module "kafka_read_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_equalities" {
+  count = local.k2hb_alarm_on_kafka_read_timeouts_equalities[local.environment] ? 1 : 0
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.7"
 
@@ -75,6 +77,7 @@ module "kafka_read_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_
 }
 
 module "hbase_batch_failures_greater_than_threshold_filter_k2hb_alarm_equalities" {
+  count = local.k2hb_alarm_on_hbase_write_timeouts_equalities[local.environment] ? 1 : 0
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.7"
 
@@ -95,6 +98,7 @@ module "hbase_batch_failures_greater_than_threshold_filter_k2hb_alarm_equalities
 }
 
 module "hbase_connection_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_equalities" {
+  count = local.k2hb_alarm_on_hbase_connection_timeouts_equalities[local.environment] ? 1 : 0
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.7"
 
@@ -127,6 +131,7 @@ resource "aws_cloudwatch_log_metric_filter" "consumer_lag_k2hb_equalities" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "consumer_lag_k2hb_alarm_equalities" {
+  count = local.k2hb_alarm_on_consumer_lag_equalities[local.environment] ? 1 : 0
   metric_name = aws_cloudwatch_log_metric_filter.consumer_lag_k2hb_equalities.name
 
   namespace           = local.cw_k2hb_equality_agent_namespace
@@ -163,6 +168,7 @@ resource "aws_cloudwatch_log_metric_filter" "failed_k2hb_batches_equalities" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "failed_k2hb_batches_exceeds_threshold_equalities" {
+  count = local.k2hb_alarm_on_failed_batches_equalities[local.environment] ? 1 : 0
   metric_name = aws_cloudwatch_log_metric_filter.failed_k2hb_batches_equalities.name
 
   namespace           = local.cw_k2hb_equality_agent_namespace

--- a/k2hb_monitoring_main.tf
+++ b/k2hb_monitoring_main.tf
@@ -35,6 +35,7 @@ resource "aws_cloudwatch_log_metric_filter" "time_to_process_batch_filter_k2hb_u
 }
 
 module "rate_of_dlq_messages_written_filter_k2hb_alarm_ucfs" {
+  count = local.k2hb_alarm_on_dlq_ucfs[local.environment] ? 1 : 0
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.7"
 
@@ -55,6 +56,7 @@ module "rate_of_dlq_messages_written_filter_k2hb_alarm_ucfs" {
 }
 
 module "kafka_read_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_ucfs" {
+  count = local.k2hb_alarm_on_kafka_read_timeouts_ucfs[local.environment] ? 1 : 0
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.7"
 
@@ -75,6 +77,7 @@ module "kafka_read_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_
 }
 
 module "hbase_batch_failures_greater_than_threshold_filter_k2hb_alarm_ucfs" {
+  count = local.k2hb_alarm_on_hbase_write_timeouts_ucfs[local.environment] ? 1 : 0
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.7"
 
@@ -95,6 +98,7 @@ module "hbase_batch_failures_greater_than_threshold_filter_k2hb_alarm_ucfs" {
 }
 
 module "hbase_connection_timeout_occurrences_greater_than_threshold_filter_k2hb_alarm_ucfs" {
+  count = local.k2hb_alarm_on_hbase_connection_timeouts_ucfs[local.environment] ? 1 : 0
   source  = "dwp/metric-filter-alarm/aws"
   version = "1.1.7"
 
@@ -127,6 +131,7 @@ resource "aws_cloudwatch_log_metric_filter" "consumer_lag_k2hb_ucfs" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "consumer_lag_k2hb_alarm_ucfs" {
+  count = local.k2hb_alarm_on_consumer_lag_ucfs[local.environment] ? 1 : 0
   metric_name = aws_cloudwatch_log_metric_filter.consumer_lag_k2hb_ucfs.name
 
   namespace           = local.cw_k2hb_main_agent_namespace
@@ -163,6 +168,7 @@ resource "aws_cloudwatch_log_metric_filter" "failed_k2hb_batches_ucfs" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "failed_k2hb_batches_exceeds_threshold_ucfs" {
+  count = local.k2hb_alarm_on_failed_batches_ucfs[local.environment] ? 1 : 0
   metric_name = aws_cloudwatch_log_metric_filter.failed_k2hb_batches_ucfs.name
 
   namespace           = local.cw_k2hb_main_agent_namespace

--- a/k2hb_monitoring_main.tf
+++ b/k2hb_monitoring_main.tf
@@ -118,30 +118,6 @@ resource "aws_cloudwatch_log_metric_filter" "kafka_write_timeout_ucfs" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "kafka_write_timeout_ucfs" {
-  count = local.k2hb_alarm_on_hbase_write_timeouts_ucfs[local.environment] ? 1 : 0
-  metric_name = aws_cloudwatch_log_metric_filter.kafka_write_timeout_ucfs.name
-
-  namespace           = local.cw_k2hb_main_agent_namespace
-  alarm_name          = "K2HB UCFS - Kafka write failures exceeds 5 in last hour"
-  alarm_description   = "Managed by ${local.common_tags.Application} repository"
-  alarm_actions       = [local.monitoring_topic_arn]
-  evaluation_periods  = 1
-  period              = 3600
-  threshold           = 5
-  statistic           = "Sum"
-  comparison_operator = "GreaterThanThreshold"
-
-  tags = merge(
-    local.common_tags,
-    {
-      Name              = "kafka-write-timeouts-ucfs",
-      notification_type = "Warning",
-      severity          = "High"
-    },
-  )
-}
-
 resource "aws_cloudwatch_log_metric_filter" "kafka_connection_timeout_ucfs" {
   log_group_name = local.k2hb_ec2_business_logs_name
   name           = local.k2hb_metric_name_timeouts_connecting_hbase
@@ -159,12 +135,12 @@ resource "aws_cloudwatch_metric_alarm" "kafka_connection_timeout_ucfs" {
   metric_name = aws_cloudwatch_log_metric_filter.kafka_connection_timeout_ucfs.name
 
   namespace           = local.cw_k2hb_main_agent_namespace
-  alarm_name          = "K2HB UCFS - Kafka connection failures exceeds 5 in last hour"
+  alarm_name          = "K2HB UCFS - Kafka connection failures exceeds 50 in last hour"
   alarm_description   = "Managed by ${local.common_tags.Application} repository"
   alarm_actions       = [local.monitoring_topic_arn]
   evaluation_periods  = 1
   period              = 3600
-  threshold           = 5
+  threshold           = 50
   statistic           = "Sum"
   comparison_operator = "GreaterThanThreshold"
 

--- a/locals.tf
+++ b/locals.tf
@@ -627,4 +627,147 @@ locals {
     production  = local.ucfs_london_bootstrap_servers[local.environment] // now on UCFS Production HA
   }
 
+  k2hb_alarm_on_consumer_lag_ucfs = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_consumer_lag_audit = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_consumer_lag_equalities = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_failed_batches_ucfs = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_failed_batches_audit = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_failed_batches_equalities = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_dlq_ucfs = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_dlq_audit = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_dlq_equalities = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_kafka_read_timeouts_ucfs = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_kafka_read_timeouts_audit = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_kafka_read_timeouts_equalities = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_hbase_write_timeouts_ucfs = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_hbase_write_timeouts_audit = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_hbase_write_timeouts_equalities = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_hbase_connection_timeouts_ucfs = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_hbase_connection_timeouts_audit = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_hbase_connection_timeouts_equalities = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
 }


### PR DESCRIPTION
Increase failed batches alarm threshold for ucfs and audit due to number of batches per hour and remove duplicate alarm that occurs in the same circumstances