### PR TITLE
Alarms k2hb

### DIFF
--- a/k2hb_monitoring_audit.tf
+++ b/k2hb_monitoring_audit.tf
@@ -227,3 +227,61 @@ resource "aws_cloudwatch_metric_alarm" "failed_k2hb_batches_exceeds_threshold_au
     },
   )
 }
+
+resource "aws_cloudwatch_metric_alarm" "processed_k2hb_batches_under_threshold_audit" {
+  count = local.k2hb_alarm_on_number_of_batches_audit[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.number_of_batches_written_filter_k2hb_audit.name
+
+  namespace           = local.cw_k2hb_main_agent_namespace
+  alarm_name          = "K2HB audit - Processed batches under 1000 in last 15 minutes"
+  alarm_description   = "Managed by ${local.common_tags.Application} repository"
+  alarm_actions       = [local.monitoring_topic_arn]
+  evaluation_periods  = 1
+  period              = 900
+  datapoints_to_alarm = 1
+  threshold           = 1000
+  statistic           = "Sum"
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "breaching"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "processed-k2hb-batches-under-threshold-audit",
+      notification_type = "Error",
+      severity          = "High",
+      active_days       = "Monday+Tuesday+Wednesday+Thursday+Friday+Sunday",
+      do_not_alert_before = "11:00",
+      do_not_alert_after = "23:59",
+    },
+  )
+}
+
+resource "aws_cloudwatch_metric_alarm" "processed_k2hb_batches_under_threshold_audit_saturday" {
+  count = local.k2hb_alarm_on_number_of_batches_audit[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.number_of_batches_written_filter_k2hb_audit.name
+
+  namespace           = local.cw_k2hb_main_agent_namespace
+  alarm_name          = "K2HB audit - Processed batches under 1000 in last 15 minutes"
+  alarm_description   = "Managed by ${local.common_tags.Application} repository"
+  alarm_actions       = [local.monitoring_topic_arn]
+  evaluation_periods  = 1
+  period              = 900
+  datapoints_to_alarm = 1
+  threshold           = 1000
+  statistic           = "Sum"
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "breaching"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "processed-k2hb-batches-under-threshold-audit",
+      notification_type = "Error",
+      severity          = "High",
+      active_days       = "Saturday",
+      do_not_alert_before = "17:00",
+      do_not_alert_after = "23:59",
+    },
+  )
+}

--- a/k2hb_monitoring_audit.tf
+++ b/k2hb_monitoring_audit.tf
@@ -239,7 +239,7 @@ resource "aws_cloudwatch_metric_alarm" "processed_k2hb_batches_under_threshold_a
   evaluation_periods  = 1
   period              = 900
   datapoints_to_alarm = 1
-  threshold           = 1000
+  threshold           = 10000
   statistic           = "Sum"
   comparison_operator = "LessThanThreshold"
   treat_missing_data  = "breaching"
@@ -268,7 +268,7 @@ resource "aws_cloudwatch_metric_alarm" "processed_k2hb_batches_under_threshold_a
   evaluation_periods  = 1
   period              = 900
   datapoints_to_alarm = 1
-  threshold           = 1000
+  threshold           = 10000
   statistic           = "Sum"
   comparison_operator = "LessThanThreshold"
   treat_missing_data  = "breaching"

--- a/k2hb_monitoring_equality.tf
+++ b/k2hb_monitoring_equality.tf
@@ -227,3 +227,61 @@ resource "aws_cloudwatch_metric_alarm" "failed_k2hb_batches_exceeds_threshold_eq
     },
   )
 }
+
+resource "aws_cloudwatch_metric_alarm" "processed_k2hb_batches_under_threshold_equalities" {
+  count = local.k2hb_alarm_on_number_of_batches_equalities[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.number_of_batches_written_filter_k2hb_equalities.name
+
+  namespace           = local.cw_k2hb_main_agent_namespace
+  alarm_name          = "K2HB equalities - Processed batches under 1000 in last 15 minutes"
+  alarm_description   = "Managed by ${local.common_tags.Application} repository"
+  alarm_actions       = [local.monitoring_topic_arn]
+  evaluation_periods  = 1
+  period              = 900
+  datapoints_to_alarm = 1
+  threshold           = 5
+  statistic           = "Sum"
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "breaching"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "processed-k2hb-batches-under-threshold-equalities",
+      notification_type = "Error",
+      severity          = "High",
+      active_days       = "Monday+Tuesday+Wednesday+Thursday+Friday+Sunday",
+      do_not_alert_before = "11:00",
+      do_not_alert_after = "23:59",
+    },
+  )
+}
+
+resource "aws_cloudwatch_metric_alarm" "processed_k2hb_batches_under_threshold_equalities_saturday" {
+  count = local.k2hb_alarm_on_number_of_batches_equalities[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.number_of_batches_written_filter_k2hb_equalities.name
+
+  namespace           = local.cw_k2hb_main_agent_namespace
+  alarm_name          = "K2HB equalities - Processed batches under 1000 in last 15 minutes"
+  alarm_description   = "Managed by ${local.common_tags.Application} repository"
+  alarm_actions       = [local.monitoring_topic_arn]
+  evaluation_periods  = 1
+  period              = 900
+  datapoints_to_alarm = 1
+  threshold           = 5
+  statistic           = "Sum"
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "breaching"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "processed-k2hb-batches-under-threshold-equalities",
+      notification_type = "Error",
+      severity          = "High",
+      active_days       = "Saturday",
+      do_not_alert_before = "17:00",
+      do_not_alert_after = "23:59",
+    },
+  )
+}

--- a/k2hb_monitoring_main.tf
+++ b/k2hb_monitoring_main.tf
@@ -227,3 +227,61 @@ resource "aws_cloudwatch_metric_alarm" "failed_k2hb_batches_exceeds_threshold_uc
     },
   )
 }
+
+resource "aws_cloudwatch_metric_alarm" "processed_k2hb_batches_under_threshold_ucfs" {
+  count = local.k2hb_alarm_on_number_of_batches_ucfs[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.number_of_batches_written_filter_k2hb_ucfs.name
+
+  namespace           = local.cw_k2hb_main_agent_namespace
+  alarm_name          = "K2HB UCFS - Processed batches under 1000 in last 15 minutes"
+  alarm_description   = "Managed by ${local.common_tags.Application} repository"
+  alarm_actions       = [local.monitoring_topic_arn]
+  evaluation_periods  = 1
+  period              = 900
+  datapoints_to_alarm = 1
+  threshold           = 1000
+  statistic           = "Sum"
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "breaching"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "processed-k2hb-batches-under-threshold-ucfs",
+      notification_type = "Error",
+      severity          = "High",
+      active_days       = "Monday+Tuesday+Wednesday+Thursday+Friday+Sunday",
+      do_not_alert_before = "11:00",
+      do_not_alert_after = "23:59",
+    },
+  )
+}
+
+resource "aws_cloudwatch_metric_alarm" "processed_k2hb_batches_under_threshold_ucfs_saturday" {
+  count = local.k2hb_alarm_on_number_of_batches_ucfs[local.environment] ? 1 : 0
+  metric_name = aws_cloudwatch_log_metric_filter.number_of_batches_written_filter_k2hb_ucfs.name
+
+  namespace           = local.cw_k2hb_main_agent_namespace
+  alarm_name          = "K2HB UCFS - Processed batches under 1000 in last 15 minutes"
+  alarm_description   = "Managed by ${local.common_tags.Application} repository"
+  alarm_actions       = [local.monitoring_topic_arn]
+  evaluation_periods  = 1
+  period              = 900
+  datapoints_to_alarm = 1
+  threshold           = 1000
+  statistic           = "Sum"
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "breaching"
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name              = "processed-k2hb-batches-under-threshold-ucfs",
+      notification_type = "Error",
+      severity          = "High",
+      active_days       = "Saturday",
+      do_not_alert_before = "17:00",
+      do_not_alert_after = "23:59",
+    },
+  )
+}

--- a/locals.tf
+++ b/locals.tf
@@ -470,24 +470,24 @@ locals {
   k2hb_main_write_to_metadata_store = {
     development = true
     qa          = true
-    integration = true
-    preprod     = true
+    integration = false # Not used in this environment
+    preprod     = false # Not used in this environment
     production  = false # Will run ad-hoc as and when needed
   }
 
   k2hb_equality_write_to_metadata_store = {
     development = true
     qa          = true
-    integration = true
-    preprod     = true
+    integration = false # Not used in this environment
+    preprod     = false # Not used in this environment
     production  = true
   }
 
   k2hb_audit_write_to_metadata_store = {
     development = true
     qa          = true
-    integration = true
-    preprod     = true
+    integration = false # Not used in this environment
+    preprod     = false # Not used in this environment
     production  = false # Will run ad-hoc as and when needed
   }
 
@@ -652,6 +652,30 @@ locals {
   }
 
   k2hb_alarm_on_failed_batches_ucfs = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_number_of_batches_ucfs = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_number_of_batches_audit = {
+    development = false
+    qa          = false
+    integration = false
+    preprod     = false
+    production  = true
+  }
+
+  k2hb_alarm_on_number_of_batches_equalities = {
     development = false
     qa          = false
     integration = false


### PR DESCRIPTION
Add k2hb volume alarms, the ners for the thresholds are based on the last week of consumption, two needed for each stack because on Saturday Kafka comes up a lot later due to weekly maintenance